### PR TITLE
LUCENE-9198 Remove news section from TLP website

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -2,10 +2,3 @@ Title: Welcome to Apache Lucene
 URL: index.html
 save_as: index.html
 Template: lucene/tlp/index
-
-The Apache Lucene<span style="vertical-align: super; font-size: xx-small">TM</span> project develops open-source search software, including:
-
-
-- *[Lucene Core](./core/)*, our flagship sub-project, provides Java-based indexing and search technology, as well as spellchecking, hit highlighting and advanced analysis/tokenization capabilities.
-- *[Solr](./solr)*<span style="vertical-align: super; font-size: xx-small">TM</span> is a high performance search server built using Lucene Core, with XML/HTTP and JSON/Python/Ruby APIs, hit highlighting, faceted search, caching, replication, and a web admin interface.
-- [PyLucene](./pylucene/index.html) is a Python wrapper around the Core project.

--- a/content/pages/pylucene/news.md
+++ b/content/pages/pylucene/news.md
@@ -1,0 +1,6 @@
+Title: PyLucene news
+URL: pylucene/news.html
+save_as: pylucene/news.html
+template: lucene/pylucene/news
+slug: pylucene-news
+

--- a/themes/lucene/static/css/lucene/global.css
+++ b/themes/lucene/static/css/lucene/global.css
@@ -713,19 +713,6 @@ input.button {
     margin-left: 20px;
 }
 
-/* Lucene and Solr logos on TLP front page */
-.front-logo-container {
-    height:110px;
-    position: relative;
-    background: none;
-}
-
-.front-logo-container img {
-    position: absolute;
-    left: 10px;
-    bottom: 5px;
-}
-
 /********************************
  Content Styles
 ********************************/
@@ -958,6 +945,19 @@ body#home #col2 {
 	float:right;
 	margin:0px 20px 0 0;
 	display:inline;
+}
+
+/* Lucene and Solr logos on TLP front page */
+.front-logo-container {
+    height:110px;
+    position: relative;
+    background: none;
+}
+
+.front-logo-container img {
+    position: absolute;
+    left: 10px;
+    bottom: 5px;
 }
 
 /*SUBPAGE - NO SIDEBAR*/

--- a/themes/lucene/static/css/lucene/global.css
+++ b/themes/lucene/static/css/lucene/global.css
@@ -559,17 +559,17 @@ input.button {
 
 #col1 {
     float: left;
-    width: 260px;
+    width: 349px;
     padding: 0;
-    margin: 20px 0 0 20px;
+    margin: 20px 0 0 10px;
     display: inline;
 }
 
 #col2 {
     float: left;
-    width: 260px;
+    width: 349px;
     padding: 0;
-    margin: 20px 0 0 20px;
+    margin: 20px 0 0 10px;
     display: inline;
 }
 
@@ -713,6 +713,18 @@ input.button {
     margin-left: 20px;
 }
 
+/* Lucene and Solr logos on TLP front page */
+.front-logo-container {
+    height:110px;
+    position: relative;
+    background: none;
+}
+
+.front-logo-container img {
+    position: absolute;
+    left: 10px;
+    bottom: 5px;
+}
 
 /********************************
  Content Styles
@@ -918,7 +930,7 @@ body#home #header #slides .mantle{
 
 body#home #col1 {
 	float: left;
-	width: 260px;
+	width: 340px;
 	padding: 0;
 	margin: 5px 0 0 0px;
 	display: inline;
@@ -926,9 +938,9 @@ body#home #col1 {
 
 body#home #col2 {
 	float: left;
-	width: 260px;
+	width: 340px;
 	padding: 0;
-	margin: 5px 0 0 20px;
+	margin: 5px 0 0 10px;
 	display: inline;
 }
 

--- a/themes/lucene/static/javascript/solr/main.js
+++ b/themes/lucene/static/javascript/solr/main.js
@@ -9,6 +9,7 @@
 
   $(function() {
     $('h2').addClass('offset');
+    $('.container .row .small-12 h2 ').removeClass('offset');
     $('.smooth-scroll').smoothScroll({ offset: 100 })
   });
 

--- a/themes/lucene/templates/lucene/tlp/_sidebar.html
+++ b/themes/lucene/templates/lucene/tlp/_sidebar.html
@@ -23,6 +23,7 @@
 <ul>
   <li><a href="https://www.apache.org/licenses/">License</a></li>
   <li><a href="{{ SITEURL }}/whoweare.html">Who We are</a></li>
+  <li><a href="{{ SITEURL }}/news.html">TLP News</a></li>
 </ul>
 
 <h1 id="events">Events<a class="headerlink" href="#events" title="Permanent link">¶</a></h1>

--- a/themes/lucene/templates/lucene/tlp/index.html
+++ b/themes/lucene/templates/lucene/tlp/index.html
@@ -3,9 +3,11 @@
 {% block content %}
 {{ super() }}
 
-The Apache Lucene<span style="vertical-align: super; font-size: xx-small">TM</span> project develops open-source search
-software. The project releases a core search library, named Lucene <span style="vertical-align: super; font-size: xx-small">TM</span>,
-as well as the Solr<span style="vertical-align: super; font-size: xx-small">TM</span> search server.
+<p>
+  The Apache Lucene<span style="vertical-align: super; font-size: xx-small">TM</span> project develops open-source search
+  software. The project releases a core search library, named Lucene <span style="vertical-align: super; font-size: xx-small">TM</span>,
+  as well as the Solr<span style="vertical-align: super; font-size: xx-small">TM</span> search server.
+</p>
 
 <div id="col1">
   <div class="front-logo-container">

--- a/themes/lucene/templates/lucene/tlp/index.html
+++ b/themes/lucene/templates/lucene/tlp/index.html
@@ -5,7 +5,7 @@
 
 <p>
   The Apache Lucene<span style="vertical-align: super; font-size: xx-small">TM</span> project develops open-source search
-  software. The project releases a core search library, named Lucene <span style="vertical-align: super; font-size: xx-small">TM</span>,
+  software. The project releases a core search library, named Lucene<span style="vertical-align: super; font-size: xx-small">TM</span> core,
   as well as the Solr<span style="vertical-align: super; font-size: xx-small">TM</span> search server.
 </p>
 

--- a/themes/lucene/templates/lucene/tlp/index.html
+++ b/themes/lucene/templates/lucene/tlp/index.html
@@ -3,23 +3,49 @@
 {% block content %}
 {{ super() }}
 
-<h1 id="lucene-project-news">Lucene<span style="vertical-align: super; font-size: xx-small">TM</span> Project News
-  <a class="headerlink" href="#lucenetm-project-news" title="Permanent link">¶</a>
-</h1>
+The Apache Lucene<span style="vertical-align: super; font-size: xx-small">TM</span> project develops open-source search
+software. The project releases a core search library, named Lucene <span style="vertical-align: super; font-size: xx-small">TM</span>,
+as well as the Solr<span style="vertical-align: super; font-size: xx-small">TM</span> search server.
 
-<div>
-  {% for article in (articles | selectattr("category.name", "eq", "news")|list)[:3] %}
-  <h2 id="{{article.slug}}">
-    {{article.locale_date|title}} - {{article.title}}
-    <a class="headerlink" href="#{{article.slug}}" title="Permanent link">¶</a>
-  </h2>
-  {{article.content}}
-  {% endfor %}
+<div id="col1">
+  <div class="front-logo-container">
+    <a href="/core/">
+      <img src="/theme/images/lucene/lucene_logo_green_300.png" width="300" alt="Lucene Logo" />
+    </a>
+  </div>
+  <p><a href="/core/">Lucene Core</a> is a Java library providing powerful indexing and search features,
+  as well as spellchecking, hit highlighting and advanced analysis/tokenization capabilities. The <a href="/pylucene/">PyLucene</a>
+    sub project provides Python bindings for Lucene Core.
+  </p>
+  <h2 id="lucene-core-news">Latest Lucene Core News</h2>
+  <div>
+    {% for article in (articles | selectattr("category.name", "eq", "core/news")|list)[:3] %}
+    <p id="{{article.slug}}">
+      <a href="/core/corenews.html#{{article.slug}}">{{article.title}}</a>
+    </p>
+    {% endfor %}
+  </div>
 </div>
-
-<div>
-  <h3>For more see <a href url="{{ SITEURL }}/news.html"> all Lucene<span style="vertical-align: super; font-size: xx-small">TM</span> Project News</a></h3>
+<div id="col2">
+  <div class="front-logo-container">
+    <a href="/solr/">
+      <img src="/theme/images/solr/Solr_Logo_200x101.png" width="200" alt="Solr Logo" />
+    </a>
+  </div>
+  <p><a href="/solr/">Solr<span style="vertical-align: super; font-size: xx-small">TM</span></a> is a high
+  performance search server built using Lucene Core. Solr is highly scalable, providing fully fault tolerant distributed
+  indexing, search and analytics. It exposes Lucene's features through easy to use JSON/HTTP interfaces or native clients
+  for Java and other languages.
+  </p>
+  <h2 id="solr-news">Latest Solr News</h2>
+  <div>
+    {% for article in (articles | selectattr("category.name", "eq", "solr/news")|list)[:3] %}
+    <p id="{{article.slug}}">
+      <a href="/solr/news.html#{{article.slug}}">{{article.title}}</a>
+    </p>
+    {% endfor %}
+  </div>
 </div>
-
+<br clear="all"/>
 {% include "lucene/_asf.html" %}
 {% endblock content %}

--- a/themes/lucene/templates/solr/news.html
+++ b/themes/lucene/templates/solr/news.html
@@ -6,18 +6,18 @@
 <div class="small-12 columns">
 
   <style type="text/css">
-.headerlink, .elementid-permalink {
-  visibility: hidden;
-}
-          h2:hover > .headerlink, h3:hover > .headerlink, h1:hover > .headerlink, h6:hover > .headerlink, h4:hover > .headerlink, h5:hover > .headerlink, dt:hover > .elementid-permalink {
-            visibility: visible
-          }
+    .headerlink, .elementid-permalink {
+      visibility: hidden;
+    }
+    h2:hover > .headerlink, h3:hover > .headerlink, h1:hover > .headerlink, h6:hover > .headerlink, h4:hover > .headerlink, h5:hover > .headerlink, dt:hover > .elementid-permalink {
+      visibility: visible;
+    }
   </style>
   <h1 id="solr-news">Solr<sup>™</sup> News<a class="headerlink" href="#solr-news" title="Permanent link">¶</a></h1>
   {{page.content}}
 
-  {% for article in (articles | selectattr("category.name", "eq", "solr/news")|list)[:15] %}
-  <h2 id="{{ article.slug }}" class="offset">{{ article.locale_date }}, {{ article.title }}
+  {% for article in (articles | selectattr("category.name", "eq", "solr/news")|list) %}
+  <h2 id="{{ article.slug }}">{{ article.locale_date }}, {{ article.title }}
     <a class="headerlink" href="#{{article.slug}}" title="Permanent link">¶</a>
   </h2>
   {{article.content}}


### PR DESCRIPTION
The massive TLP news section is removed from the frontpage and replaced with two columns introducing Lucene, PyLycene and Solr, also displaying last 3 news headlines from each of these.