### PR TITLE
Conditionally show security warning block only if news last 60 days.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,13 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 charset = utf-8
-indent_size = 4
+indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.html]
-indent_size = 2
-
-[*.css]
-indent_size = 2

--- a/themes/lucene/static/css/solr/base.css
+++ b/themes/lucene/static/css/solr/base.css
@@ -519,6 +519,7 @@ section.orange.full-width {
   background-color: #cccc33;
   padding-top: 10px;
   padding-bottom: 0px;
+  display: none;
 }
 
 .security a {

--- a/themes/lucene/static/javascript/solr/main.js
+++ b/themes/lucene/static/javascript/solr/main.js
@@ -29,7 +29,12 @@
     $('h2').addClass('offset');
     $('.container .row .small-12 h2').removeClass('offset');
     $('.security .row .large-12 h2').removeClass('offset');
-    $('.smooth-scroll').smoothScroll({ offset: 100 })
+    $('.smooth-scroll').smoothScroll({ offset: 100 });
+    // Conditionally show security news block
+    var latest_sec_days = (new Date() - new Date($('.security').attr('latest-date'))) / (1000*60*60*24);
+    if (latest_sec_days < 60) {
+      $('.security').show();
+    }
   });
 
   /*

--- a/themes/lucene/templates/solr/index.html
+++ b/themes/lucene/templates/solr/index.html
@@ -3,16 +3,15 @@
 {% block bodyclass %}homepage{% endblock %}
 
 {% block security_warning %}
-{% set num_security_news_90d = articles | selectattr("category.name", "eq", "solr/security") | selectattr("date", "age_days_lt", 90) | list | length %}
-{% if num_security_news_90d > 0 %}
-<section class="security">
+{% set latest_sec_articles = (articles | selectattr("category.name", "eq", "solr/security") | list)[:1] %}
+{% set latest_date = latest_sec_articles[0].date | strftime("%Y-%m-%d") %}
+<section class="security" latest-date="{{ latest_date }}">
   <div class="row">
     <div class="large-12 columns text-center">
       <h2><a href="security.html">There are recent security announcements. Read more on the Security page.</a></h2>
     </div>
   </div>
 </section>
-{% endif %}
 {% endblock %}
 
 {% block content_inner %}


### PR DESCRIPTION
SOLR-13910 followup

This PR converts from static calculation in Pelican of age for last secuity news, to dynamic calculation in JS, so the yellow warning box goes away without re-publish.

I also chose 60 days as "recent" instead of 90 days.