### PR TITLE
Add GitHub Topics, helps find ASF website examples

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -4,3 +4,9 @@ pelican:
 
 staging:
   whoami: asf-staging
+
+github:
+  labels:
+    - lucene
+    - website
+    - pelican


### PR DESCRIPTION
https://infra.apache.org/project-site.html already has queries to find ASF websites created using various tools [1], I suggest adding the "website, pelican" topics to this repo so it can be listed as a Pelican example

[1] like https://github.com/search?q=topic%3Ahugo+org%3Aapache&type=Repositories