### PR TITLE
Clarify merge strategy

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -14,3 +14,6 @@ github:
     squash: true
     merge:  true
     rebase: false
+  protected_branches:
+    master
+    production

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -12,5 +12,5 @@ github:
     - pelican
   enabled_merge_buttons:
     squash: true
-    merge:  false
+    merge:  true
     rebase: false

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The site is written in [Markdown][9] syntax and built into a static site using [
  
 If the staged site looks good, simply merge the changes to branch `production` and the site will be deployed in a minute or two. Note that simple edits can also be done directly in the GitHub UI rather than clone -> edit -> commit -> push.
 
+> **IMPORTANT**: Please never commit directly to `production` branch. All commits should go to master, and then merge master to production. Note that it **is** possible to make a Pull Request for the merge from `master-->production`. If you do so, please merge using a merge commit rather than a squash merge.
+
 For larger edits it is recommended to build and preview the site locally. This lets you see the result of your changes instantly without committing anything. The next sections detail that procedure. The TL;DR instructions goes like this:
 
     # Usage: ./build.sh [-l] [<other pelican arguments>]


### PR DESCRIPTION
To avoid production and master branches for the website coming out of sync, we clarify that all edits should be committed to master branch, and then merge master -> production branch.

Also allow merge commit from GitHub UI  merge button, and not force squash commit, which will allow us to use the UI to do the merge from master->production.