### PR TITLE
clickable links

### DIFF
--- a/content/pages/solr/community.md
+++ b/content/pages/solr/community.md
@@ -130,8 +130,8 @@ wealth of information about how to get the most out of the IRC channels.
 * The project's Slack channel are the `#lucene-dev` and `#solr-dev` channels in the `the-asf` organization. These are primarily for developer discussions and not meant as support channels. Link: <https://the-asf.slack.com/messages/CE70MDPMF>
 
 * There are unofficial slack organizations for Solr support
-    * A community maintained/unofficial Slack organization that relays messages bi-directionally to/from the official IRC channels. Link: https://s.apache.org/solr-slack
-    * For relevance related discussions (Solr or other search engines), there's Relevance Slack: https://opensourceconnections.com/slack
+    * A community maintained/unofficial Slack organization that relays messages bi-directionally to/from the official IRC channels. Link: <https://s.apache.org/solr-slack>
+    * For relevance related discussions (Solr or other search engines), there's Relevance Slack: <https://opensourceconnections.com/slack>
 
 ## Issue tracker ##
 

--- a/content/pages/solr/community.md
+++ b/content/pages/solr/community.md
@@ -127,7 +127,7 @@ wealth of information about how to get the most out of the IRC channels.
 
 #### Slack ####
 
-* The project's Slack channel are the `#lucene-dev` and `#solr-dev` channels in the `the-asf` organization. These are primarily for developer discussions and not meant as support channels. Link: <https://the-asf.slack.com/messages/CE70MDPMF>
+* The project's Slack channels are `#lucene-dev` and `#solr-dev` in the `the-asf` organization. These are primarily for developer discussions and not meant as support channels. Link: <https://the-asf.slack.com/messages/CE70MDPMF>
 
 * There are unofficial slack organizations for Solr support
     * A community maintained/unofficial Slack organization that relays messages bi-directionally to/from the official IRC channels. Link: <https://s.apache.org/solr-slack>

--- a/content/pages/solr/community.md
+++ b/content/pages/solr/community.md
@@ -131,7 +131,7 @@ wealth of information about how to get the most out of the IRC channels.
 
 * There are unofficial slack organizations for Solr support
     * A community maintained/unofficial Slack organization that relays messages bi-directionally to/from the official IRC channels. Link: <https://s.apache.org/solr-slack>
-    * For relevance related discussions (Solr or other search engines), there's Relevance Slack: <https://opensourceconnections.com/slack>
+    * For relevance related discussions (Solr and other search engines), there's Relevance Slack: <https://relevancy.slack.com>.    Sign up via <https://opensourceconnections.com/slack>
 
 ## Issue tracker ##
 


### PR DESCRIPTION
Make the community links on https://lucene.apache.org/solr/community.html#slack actually clickable!