### PR TITLE
Revert the #solr slack channel edits to lucene-core discussion page

### DIFF
--- a/content/pages/core/discussion.md
+++ b/content/pages/core/discussion.md
@@ -86,11 +86,7 @@ but developers should be careful to transfer all the official decisions or usefu
 
 ## Slack
 
-* The project's Slack channel are the `#lucene-dev` and `#solr-dev` channels in the `the-asf` organization. These are primarily for developer discussions and not meant as support channels. Link: <https://the-asf.slack.com/messages/CE70MDPMF>
-
-* There are unofficial slack organizations for Solr support
-    * A community maintained/unofficial Slack organization that relays messages bi-directionally to/from the official IRC channels. Link: https://s.apache.org/solr-slack
-    * For relevance related discussions (Solr or other search engines), there's Relevance Slack: https://opensourceconnections.com/slack
+The project's Slack channel is the **#lucene-dev** channel in the **the-asf** organization. Link: <https://the-asf.slack.com/messages/CE70MDPMF>
 
 ## Mail Archives
 


### PR DESCRIPTION
As mentioned in #39 I think it was a mistake to add Solr-specific slack channel info to the lucene core (java) sub page. This PR reverts that change.