### PR TITLE
Upgrade Pelican and dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-pelican==4.2.0
-Markdown>=3.1.1
-checksumdir>=1.0.5
+pelican==4.5.4
+Markdown>=3.3.3
+checksumdir>=1.2.0
 
 # Pelican plugins
-mdx-include==1.3.3
-beautifulsoup4>=4.8.1
+mdx-include==1.4.1
+beautifulsoup4>=4.9.3
 
 # Dev tools
-invoke>=1.3.0
-livereload>=2.6.1
+invoke>=1.5.0
+livereload>=2.6.3


### PR DESCRIPTION
I got a strange error when trying to run pelican in live mode.

    CRITICAL: TypeError: cannot pickle 'generator' object

Upgrading pelican and other dependencies solved the issue for me.