### PR TITLE
Edits related to switching from master to main branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,5 +1,5 @@
 pelican:
-  whoami: master
+  whoami: main
   target: asf-staging
 
 staging:
@@ -16,6 +16,6 @@ github:
     merge:  true
     rebase: false
   protected_branches:
-    master
+    main
     production
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This repository contains the "source code" of the Lucene website at [lucene.apac
 
 ## Building the site
 
-The site is written in [Markdown][9] syntax and built into a static site using [Pelican][1]. The site is re-built automatically by [ASF Buildbot][5] on every push to master branch and the result can be previewed at [lucene.staged.apache.org][6]. Build success/failure emails are sent to [commits@lucene.apache.org][7] mailing list. Read more about the mechanics behind auto building in [INFRA Confluence][8].
+The site is written in [Markdown][9] syntax and built into a static site using [Pelican][1]. The site is re-built automatically by [ASF Buildbot][5] on every push to main branch and the result can be previewed at [lucene.staged.apache.org][6]. Build success/failure emails are sent to [commits@lucene.apache.org][7] mailing list. Read more about the mechanics behind auto building in [INFRA Confluence][8].
  
 If the staged site looks good, simply merge the changes to branch `production` and the site will be deployed in a minute or two. Note that simple edits can also be done directly in the GitHub UI rather than clone -> edit -> commit -> push.
 
-> **IMPORTANT**: Please never commit directly to `production` branch. All commits should go to master, and then merge master to production. Note that it **is** possible to make a Pull Request for the merge from `master-->production`. If you do so, please merge using a merge commit rather than a squash merge.
+> **IMPORTANT**: Please never commit directly to `production` branch. All commits should go to main, and then merge main to production. Note that it **is** possible to make a Pull Request for the merge from `main-->production`. If you do so, please merge using a merge commit rather than a squash merge.
 
 For larger edits it is recommended to build and preview the site locally. This lets you see the result of your changes instantly without committing anything. The next sections detail that procedure. The TL;DR instructions goes like this:
 

--- a/content/pages/site-instructions.md
+++ b/content/pages/site-instructions.md
@@ -7,4 +7,4 @@ template: lucene/tlp/page
 
 The web site is hosted in its own git repository `lucene-site` (see [Github](https://github.com/apache/lucene-site/) and [Gitbox](https://gitbox.apache.org/repos/asf/lucene-site.git)).
 
-Pushing to the `master` branch will update the [staging site](https://lucene.staged.apache.org) while pushing to `production` branch will update the main web site. Read the [README.md](https://github.com/apache/lucene-site/blob/master/README.md) file for further instructions.
+Pushing to the `main` branch will update the [staging site](https://lucene.staged.apache.org) while pushing to `production` branch will update the main web site. Read the [README.md](https://github.com/apache/lucene-site/blob/main/README.md) file for further instructions.


### PR DESCRIPTION
We need edits to README and site-instructions.

Also `asf.yaml` needs to refer to 'main' as whoami, so the site will be built from this branch.

NB: Don't merge this PR to main branch until we are ready to do the switch (i.e. INFRA has changed default branch?), else a site build will kick off and change the site prematurely.