### PR TITLE
PYLUCENE-57 Add DOAP file for pylucene

### DIFF
--- a/content/pylucene/doap.rdf
+++ b/content/pylucene/doap.rdf
@@ -1,0 +1,241 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="https://lucene.apache.org/pylucene/index.html">
+    <created>2009-01-08</created>
+    <license rdf:resource="https://spdx.org/licenses/Apache-2.0" />
+    <name>Apache PyLucene</name>
+    <homepage rdf:resource="https://lucene.apache.org/pylucene/index.html" />
+    <asfext:pmc rdf:resource="https://lucene.apache.org" />
+    <shortdesc>PyLucene is a Python extension for accessing Java Lucene.</shortdesc>
+    <description>PyLucene is a Python extension for accessing Java Lucene TM. Its goal is to allow you to use Lucene's text indexing and searching capabilities from Python.</description>
+    <bug-database rdf:resource="https://issues.apache.org/jira/projects/PYLUCENE" />
+    <mailing-list rdf:resource="https://lucene.apache.org/pylucene/mailing-lists.html" />
+    <download-page rdf:resource="https://www.apache.org/dyn/closer.lua/lucene/pylucene/" />
+    <programming-language>C++</programming-language>
+    <programming-language>Python</programming-language>
+    <category rdf:resource="http://projects.apache.org/category/search" />
+    <category rdf:resource="http://projects.apache.org/category/library" />
+    <category rdf:resource="http://projects.apache.org/category/python" />
+    <category rdf:resource="http://projects.apache.org/category/c++" />
+    <release>
+      <Version>
+        <name>pylucene-8.8.1</name>
+        <created>2021-03-08</created>
+        <revision>8.8.1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-8.6.1</name>
+        <created>2020-09-09</created>
+        <revision>8.6.1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-8.3.0</name>
+        <created>2020-04-29</created>
+        <revision>8.3.0</revision>
+      </Version>
+      <Version>
+        <name>pylucene-8.1.1</name>
+        <created>2019-09-11</created>
+        <revision>8.1.1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-7.7.1</name>
+        <created>2019-03-18</created>
+        <revision>7.7.1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-7.6.0</name>
+        <created>2019-01-11</created>
+        <revision>7.6.0</revision>
+      </Version>
+      <Version>
+        <name>pylucene-7.5.0</name>
+        <created>2018-10-19</created>
+        <revision>7.5.0</revision>
+      </Version>
+      <Version>
+        <name>pylucene-7.4.0</name>
+        <created>2018-09-03</created>
+        <revision>7.4.0</revision>
+      </Version>
+      <Version>
+        <name>pylucene-6.5.0</name>
+        <created>2017-04-06</created>
+        <revision>6.5.0</revision>
+      </Version>
+      <Version>
+        <name>pylucene-6.4.1</name>
+        <created>2017-02-14</created>
+        <revision>6.4.1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-6.2.0</name>
+        <created>2016-09-18</created>
+        <revision>6.2.0</revision>
+      </Version>
+      <Version>
+        <name>pylucene-4.10.1-1</name>
+        <created>2014-10-06</created>
+        <revision>4.10.1-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-4.9.0-0</name>
+        <created>2014-07-17</created>
+        <revision>4.9.0-0</revision>
+      </Version>
+      <Version>
+        <name>pylucene-4.8.0-1</name>
+        <created>2014-05-03</created>
+        <revision>4.8.0-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-4.7.2-1</name>
+        <created>2014-04-28</created>
+        <revision>4.7.2-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-4.6.1-1</name>
+        <created>2014-02-13</created>
+        <revision>4.6.1-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-4.5.1-1</name>
+        <created>2013-11-04</created>
+        <revision>4.5.1-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-4.4.0-1</name>
+        <created>2013-08-23</created>
+        <revision>4.4.0-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-4.3.0-1</name>
+        <created>2013-05-14</created>
+        <revision>4.3.0-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.6.2-1</name>
+        <created>2013-01-04</created>
+        <revision>3.6.2-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.6.1-2</name>
+        <created>2012-08-24</created>
+        <revision>3.6.1-2</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.6.0-2</name>
+        <created>2012-05-11</created>
+        <revision>3.6.0-2</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.5.0-3</name>
+        <created>2011-12-12</created>
+        <revision>3.5.0-3</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.4.0-1</name>
+        <created>2011-09-19</created>
+        <revision>3.4.0-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.3.3</name>
+        <created>2011-07-23</created>
+        <revision>3.3.3</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.2.0-1</name>
+        <created>2011-06-09</created>
+        <revision>3.2.0-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.1.0-1</name>
+        <created>2011-04-04</created>
+        <revision>3.1.0-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.0.3-1</name>
+        <created>2010-12-16</created>
+        <revision>3.0.3-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-2.9.4-1</name>
+        <created>2010-12-16</created>
+        <revision>2.9.4-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.0.2-1</name>
+        <created>2010-07-02</created>
+        <revision>3.0.2-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-2.9.3-1</name>
+        <created>2010-07-02</created>
+        <revision>2.9.3-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.0.1-1</name>
+        <created>2010-03-03</created>
+        <revision>3.0.1-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-2.9.2-1</name>
+        <created>2010-03-03</created>
+        <revision>2.9.2-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-3.0.0-1</name>
+        <created>2009-12-08</created>
+        <revision>3.0.0-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-2.9.1-1</name>
+        <created>2009-11-10</created>
+        <revision>2.9.1-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-2.9.0-1</name>
+        <created>2009-10-13</created>
+        <revision>2.9.0-1</revision>
+      </Version>
+      <Version>
+        <name>pylucene-2.4.1-1</name>
+        <created>2009-04-03</created>
+        <revision>2.4.1-1</revision>
+      </Version>
+    </release>
+    <repository>
+      <SVNRepository>
+        <location rdf:resource="https://svn.apache.org/repos/asf/lucene/pylucene/"/>
+        <browse rdf:resource="https://svn.apache.org/viewvc/lucene/pylucene/"/>
+      </SVNRepository>
+    </repository>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Apache Lucene</foaf:name>
+          <foaf:mbox rdf:resource="mailto:dev@lucene.apache.org"/>
+      </foaf:Person>
+    </maintainer>
+  </Project>
+</rdf:RDF>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/PYLUCENE-57

Next step is to add a reference to the file (https://lucene.apache.org/pylucene/doap.rdf) to https://svn.apache.org/repos/asf/comdev/projects.apache.org/trunk/data/projects.xml in svn, and next day it will be listed as a sub project under Lucene TLP at https://projects.apache.org/committee.html?lucene