### PR TITLE
Update ASF banner style

### DIFF
--- a/themes/lucene/templates/lucene/_javascript.html
+++ b/themes/lucene/templates/lucene/_javascript.html
@@ -1,3 +1,4 @@
 <script type="text/javascript" src="{{ SITEURL }}/theme/javascript/lucene/prototype.js{{ STATIC_RESOURCE_SUFFIX }}"></script>
 <script type="text/javascript" src="{{ SITEURL }}/theme/javascript/lucene/effects.js{{ STATIC_RESOURCE_SUFFIX }}"></script>
 <script type="text/javascript" src="{{ SITEURL }}/theme/javascript/lucene/slides.js{{ STATIC_RESOURCE_SUFFIX }}"></script>
+<script src="https://www.apachecon.com/event-images/snippet.js"></script>

--- a/themes/lucene/templates/lucene/core/_sidebar.html
+++ b/themes/lucene/templates/lucene/core/_sidebar.html
@@ -29,7 +29,7 @@
 
 <h1 id="events">Events</h1>
 <ul>
-  <li><a href="https://www.apache.org/events/current-event.html" target="_blank"><img src="https://www.apache.org/events/current-event-125x125.png"></a></li>
+  <a class="acevent" data-format="square" data-mode="light" data-width="160" data-style="border: 1px solid lightgrey"></a>
 </ul>
 
 <h1 id="asf-links">ASF links</h1>

--- a/themes/lucene/templates/lucene/openrelevance/_sidebar.html
+++ b/themes/lucene/templates/lucene/openrelevance/_sidebar.html
@@ -6,7 +6,7 @@
 
 <h1 id="events">Events<a class="headerlink" href="#events" title="Permanent link">¶</a></h1>
 <ul>
-  <li><a href="https://www.apache.org/events/current-event.html" target="_blank"><img src="https://www.apache.org/events/current-event-125x125.png"></a></li>
+  <a class="acevent" data-format="square" data-mode="light" data-width="160" data-style="border: 1px solid lightgrey"></a>
 </ul>
 
 <h1 id="asf-links">ASF links<a class="headerlink" href="#asf-links" title="Permanent link">¶</a></h1>

--- a/themes/lucene/templates/lucene/pylucene/_sidebar.html
+++ b/themes/lucene/templates/lucene/pylucene/_sidebar.html
@@ -15,7 +15,7 @@
 
 <h1 id="events">Events<a class="headerlink" href="#events" title="Permanent link">¶</a></h1>
 <ul>
-  <li><a href="https://www.apache.org/events/current-event.html" target="_blank"><img src="https://www.apache.org/events/current-event-125x125.png"></a></li>
+  <a class="acevent" data-format="square" data-mode="light" data-width="160" data-style="border: 1px solid lightgrey"></a>
 </ul>
 
 <h1 id="asf-links">ASF links<a class="headerlink" href="#asf-links" title="Permanent link">¶</a></h1>

--- a/themes/lucene/templates/lucene/pylucene/jcc/_sidebar.html
+++ b/themes/lucene/templates/lucene/pylucene/jcc/_sidebar.html
@@ -7,7 +7,7 @@
 
 <h1 id="events">Events<a class="headerlink" href="#events" title="Permanent link">¶</a></h1>
 <ul>
-  <li><a href="https://www.apache.org/events/current-event.html" target="_blank"><img src="https://www.apache.org/events/current-event-125x125.png"></a></li>
+  <a class="acevent" data-format="square" data-mode="light" data-width="160" data-style="border: 1px solid lightgrey"></a>
 </ul>
 
 <h1 id="asf-links">ASF links<a class="headerlink" href="#asf-links" title="Permanent link">¶</a></h1>

--- a/themes/lucene/templates/lucene/tlp/_sidebar.html
+++ b/themes/lucene/templates/lucene/tlp/_sidebar.html
@@ -22,7 +22,7 @@
 
 <h1 id="events">Events<a class="headerlink" href="#events" title="Permanent link">¶</a></h1>
 <ul>
-  <li><a href="https://www.apache.org/events/current-event.html" target="_blank"><img src="https://www.apache.org/events/current-event-125x125.png"></a></li>
+  <a class="acevent" data-format="square" data-mode="light" data-width="160" data-style="border: 1px solid lightgrey"></a>
 </ul>
 
 <h1 id="asf-links">ASF links<a class="headerlink" href="#asf-links" title="Permanent link">¶</a></h1>


### PR DESCRIPTION
Received an email to members@ about a new way to include ApacehCon banner on the websites. See https://www.apachecon.com/event-images/

This PR updates this for Lucene, see screenshot below. I have made the banner a bit larger and light color instead of black since it is on a white backround.

### Before/After screenshots:
<table border="0">
 <tr>
    <td>
<img src="https://user-images.githubusercontent.com/409128/111810944-d736be00-88d6-11eb-9b1c-c7437ef7e164.png"/>
</td>
<td>...</td>
    <td>
<img src="https://user-images.githubusercontent.com/409128/111810970-ddc53580-88d6-11eb-86fa-af7306a591c0.png"/>
</td>
 </tr>
</table>
