### PR TITLE
Fix github page title

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -6,6 +6,7 @@ staging:
   whoami: asf-staging
 
 github:
+  description: "Apache Lucene website"
   labels:
     - apache
     - lucene


### PR DESCRIPTION
Github repo currently says "Apache Lucene and Solr web site"