### PR TITLE
Specify package versions where necessary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 pelican==4.5.4
 Markdown==3.3.3
 checksumdir>=1.2.0
+markupsafe==2.0.1
+importlib-metadata<5.0
 
 # Pelican plugins
 mdx-include==1.4.1


### PR DESCRIPTION
I recently pushed #74 and wanted to test the change locally. I had to downgrade two of the dependencies to be able to build the website (`./build.sh -l`). These are the changes I made.