### PR TITLE
update privacy policy link

### DIFF
--- a/content/pages/privacy.md
+++ b/content/pages/privacy.md
@@ -1,7 +1,0 @@
-Title: Privacy Policy
-URL: privacy.html
-save_as: privacy.html
-template: lucene/tlp/page
-
-Information about your use of this website is collected using server access logs, and stored in aggregated and
-anonoymized form for the purpose of usage statistics. We don't use 3rd party trackers.

--- a/themes/lucene/templates/lucene/_footer.html
+++ b/themes/lucene/templates/lucene/_footer.html
@@ -2,7 +2,7 @@
   <div class="copyright">
     <p>
       Copyright &copy; 2011-{{ CURRENTYEAR }} The Apache Software Foundation, Licensed under
-      the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.  {% block privacy %}<a href="{{ SITERUL }}/privacy.html">Privacy Policy</a>{% endblock %}
+      the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.  {% block privacy %}<a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a>{% endblock %}
       <br/>
       Apache and the Apache feather logo are trademarks of The Apache Software Foundation.  Apache Lucene, Apache Solr and their
       respective logos are trademarks of the Apache Software Foundation.  Please see the <a href="https://www.apache.org/foundation/marks/">Apache Trademark Policy</a>


### PR DESCRIPTION
The "Apache Project Website Checks" at https://whimsy.apache.org/site/project/lucene identify

```
<head></head>
Privacy | https://lucene.apache.org/privacy.html | URL expected to match regular expression: \Ahttps://privacy\.apache\.org/policies/privacy-policy-public\.html\z \| \Ahttps?://(?:www\.)?apache\.org/foundation/policies/privacy\.html\zAll websites must link to the Privacy Policy.
-- | -- | --


[Privacy](https://whimsy.apache.org/site/check/privacy)	https://lucene.apache.org/privacy.html	URL expected to match regular expression: \Ahttps://privacy\.apache\.org/policies/privacy-policy-public\.html\z | \Ahttps?://(?:www\.)?apache\.org/foundation/policies/privacy\.html\z
[All websites must link to the Privacy Policy.](https://www.apache.org/foundation/marks/pmcs.html#navigation)
```