### PR TITLE
Add Issue Tracker Link under 'Editing Content on the Lucene™ Sites'

### DIFF
--- a/content/pages/site-instructions.md
+++ b/content/pages/site-instructions.md
@@ -3,6 +3,7 @@ URL: site-instructions.html
 save_as: site-instructions.html
 template: lucene/tlp/page
 
+
 ## Editing Content on the Lucene™ sites
 The web site is hosted in its own git repository **lucene-site** (see [Github](https://github.com/apache/lucene-site) and [Gitbox](https://gitbox.apache.org/repos/asf?p=lucene-site.git)).
 

--- a/content/pages/site-instructions.md
+++ b/content/pages/site-instructions.md
@@ -9,4 +9,4 @@ The web site is hosted in its own git repository **lucene-site** (see [Github](h
 
 Pushing to the `main` branch will update the staging site while pushing to `production` branch will update the main web site. Read the `README.md` file for further instructions.
 
-For reporting website-related issues or suggesting improvements, please visit our [Issue Tracker](https://issues.apache.org/jira/projects/LUCENE).
+For reporting website-related issues or suggesting improvements, please use [GitHub Issues](https://github.com/apache/lucene-site/issues).

--- a/content/pages/site-instructions.md
+++ b/content/pages/site-instructions.md
@@ -4,7 +4,8 @@ save_as: site-instructions.html
 template: lucene/tlp/page
 
 ## Editing Content on the Lucene™ sites
+The web site is hosted in its own git repository **lucene-site** (see [Github](https://github.com/apache/lucene-site) and [Gitbox](https://gitbox.apache.org/repos/asf?p=lucene-site.git)).
 
-The web site is hosted in its own git repository `lucene-site` (see [Github](https://github.com/apache/lucene-site/) and [Gitbox](https://gitbox.apache.org/repos/asf/lucene-site.git)).
+Pushing to the `main` branch will update the staging site while pushing to `production` branch will update the main web site. Read the `README.md` file for further instructions.
 
-Pushing to the `main` branch will update the [staging site](https://lucene.staged.apache.org) while pushing to `production` branch will update the main web site. Read the [README.md](https://github.com/apache/lucene-site/blob/main/README.md) file for further instructions.
+For reporting website-related issues or suggesting improvements, please visit our [Issue Tracker](https://issues.apache.org/jira/projects/LUCENE).


### PR DESCRIPTION
This PR adds a direct link to the [Lucene Issue Tracker](https://issues.apache.org/jira/projects/LUCENE) under the "Editing Content on the Lucene™ sites" section in site-instructions.md.

Changes Made:

- Updated site-instructions.md to include a reference to the issue tracker.
- Placed the link right after the mention of the GitHub and Gitbox repositories for better visibility.

Reason for the Change:

- Helps contributors quickly find where to report website-related issues.
- Improves documentation clarity and accessibility.

Fixes #72 